### PR TITLE
Update Cargo.toml

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ actix-multipart = { version = "0", optional = true }
 actix-session = { version = "0", optional = true }
 actix-identity = { version = "0", optional = true }
 actix-files = { version = "0", optional = true }
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4", default-features = false, optional = true }
 heck = { version = "0.4", optional = true }
 once_cell = "1.4"
 log = { version = "0.4", optional = true }


### PR DESCRIPTION
Do not use default chrono features to avoid any unrequired dependency to time lib (related to RUSTSEC-2020-0071).